### PR TITLE
Constantize inside a namespace [WIP]

### DIFF
--- a/lib/inflecto.rb
+++ b/lib/inflecto.rb
@@ -100,21 +100,23 @@ module Inflecto
   # The name is assumed to be the one of a top-level constant, constant scope of caller is ignored
   #
   # @param [String] input
+  # @param [Module] namespace
   #
   # @example
   #
   #   Inflecto.constantize("Module")            # => Module
-  #   Inflecto.constantize("DataMapper::Error") # => DataMapper::Error
+  #   Inflecto.constantize("Test::Unit")        # => Test::Unit
+  #   Inflecto.constantize("Unit", Test)        # => Test::Unit
   #
   # @return [Class, Module]
   #
   # @api public
   #
-  def self.constantize(input)
+  def self.constantize(input, namespace = Object)
     names = input.split('::')
     names.shift if names.first.empty?
 
-    names.inject(Object) do |constant, name|
+    names.inject(namespace) do |constant, name|
       if constant.const_defined?(name, false)
         constant.const_get(name)
       else

--- a/spec/unit/inflecto/class_methods/constantize_spec.rb
+++ b/spec/unit/inflecto/class_methods/constantize_spec.rb
@@ -57,4 +57,8 @@ describe Inflecto, '.constantize' do
       Inflecto.constantize(i('Qwerty'))
     }.to raise_error(NameError)
   end
+
+  it 'searches inside an optional namespace' do
+    Inflecto.constantize(i('Inflections'), Inflecto).should == Inflecto::Inflections
+  end
 end


### PR DESCRIPTION
Rebased and solved conflicts https://github.com/mbj/inflecto/pull/12

cc: @sagmor

@Ptico I have to think better about this.

First, one of the metrics have raised.
Second, I don't see the difference from `constantize` to `Object.const_get`
This was important at the time Ruby doesn't automatically searched nested constants with `Object.const_get`. This is not true anymore.

```ruby
Object.const_get('Object::TrueClass') #=> TrueClass

Inflecto.constantize('Object::TrueClass') #=> TrueClass
```

I have to check from what ruby version on this is true.

Linking the AS implementation for reference
See: http://api.rubyonrails.org/classes/ActiveSupport/Inflector.html#method-i-constantize

Any thoughts on this?