### PR TITLE
[Don't MERGE] A first step towards testing dry-inflector compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,5 @@ gemspec
 group :development, :test do
   gem 'devtools', '~> 0.1.x'
 end
+
+gem "dry-inflector", github: "dry-rb/dry-inflector"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,7 +13,29 @@ if ENV['COVERAGE'] == 'true'
   end
 end
 
-require 'flexus'
+require 'dry/inflector'
+
+class Flexus
+  extend SingleForwardable
+
+  def_single_delegators :instance,
+    :camelize, :underscore, :dasherize,
+    :demodulize, :foreign_key, :constantize,
+    :ordinalize, :inflections, :pluralize,
+    :singularize, :humanize, :tableize,
+    :classify, :uncountable?, :underscorize
+
+  def self.instance
+    @__instance__ ||= Dry::Inflector.new
+  end
+end
+
+def self.Flexus()
+  Flexus.instance
+end
+
+Flexus::Inflections = Dry::Inflector::Inflections
+Flexus::RulesCollection = Dry::Inflector::Rules
 
 # require spec support files and shared behavior
 Dir[File.expand_path('../{support,shared}/**/*.rb', __FILE__)].each do |file|


### PR DESCRIPTION
Discussion only PR.

I'm trying to inject dry-inflector on current flexus code to check what tests break and see how we could make an optional compatibility layer for dry-inflector so people coming from inflecto/flexus could have an easy transition.

A lot of internal unit tests broken but this doesn't matter much.
But, I could spot some things that we should port to dry-inflector (example the recent fix for address singularization at #2  mbj/inflecto#16 ).

Unfortunately, I'll be travelling tomorrow, coming back only on saturday.
As soon as possible I'll try to have a look at it. But I can't promise to do this while travelling.
So, if anybody have time and want to go on with this, I'm fine with that.
